### PR TITLE
Pass a URI string to `browse-url`, supports Windows

### DIFF
--- a/src/com/walmartlabs/vizdeps/common.clj
+++ b/src/com/walmartlabs/vizdeps/common.clj
@@ -94,7 +94,7 @@
     (d/save! dot output-file {:format output-format})
 
     (when-not no-view
-      (browse-url output-path)))
+      (browse-url (-> output-file .toURI .toString))))
 
   nil)
 


### PR DESCRIPTION
Using the `vizdeps` plugins with defaults would result in an exception saying that the path could not be found. The string passed to [`open-url-in-browser`](https://github.com/clojure/clojure/blob/ef00c7cffad10e6104d333f7f71a29163b06cd0a/src/clj/clojure/java/browse.clj#L52) would not work on Windows when provided with a path that wasn't already a URI string.

This small change will ensure that `browse-url` has a path that will work on Windows as well.

I don't have a readily available Linux VM that I can test on, but I don't see why this wouldn't work on any other operating system.