### PR TITLE
Fixed issue with lein-parent projects and managed-dependencies

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject walmartlabs/vizdeps "0.2.0"
+(defproject cc.artifice/vizdeps "0.2.1-josh"
   :description "Visualize Leiningen project dependencies using Graphviz."
   :url "https://github.com/walmartlabs/vizdeps"
   :license {:name "Apache Sofware License 2.0"

--- a/src/leiningen/vizdeps.clj
+++ b/src/leiningen/vizdeps.clj
@@ -48,6 +48,8 @@
   [dependency-graph artifact-name artifact-version dependencies]
   (reduce (fn [g dep]
             (let [[dep-name dep-version] dep
+                  ;; get version from parent project if not found in this project
+                  dep-version (or dep-version (second (get-in dependency-graph [:dependencies dep-name])))
                   g-1 (add-dependency-tree g dep-name dep-version)]
               (if-let [dep-artifact (get-in g-1 [:artifacts dep-name])]
                 (let [dep-map {:artifact-name dep-name


### PR DESCRIPTION
vizdeps would crash when using managed-dependencies in a parent project due to a missing version in the root project.